### PR TITLE
Correctly determine $PASS_COLUMN_NAME, Fixing #22

### DIFF
--- a/mysqltuner.pl
+++ b/mysqltuner.pl
@@ -3306,37 +3306,20 @@ sub security_recommendations {
 
     infoprint "$myvar{'version_comment'} - $myvar{'version'}";
 
-    my $PASS_COLUMN_NAME = 'password';
+    my $PASS_COLUMN_NAME;
 
-    # New table schema available since mysql-5.7 and mariadb-10.2
-    # But need to be checked
-    if (
-        ( $myvar{'version'} =~ /5\.7/ )
-        or (
-            ( $myvar{'version'} =~ /10\.[2-5]\..*/ )
-            and (  ( $myvar{'version'} =~ /MariaDB/i )
-                or ( $myvar{'version_comment'} =~ /MariaDB/i ) )
-        )
-      )
-    {
-        my $result_pass = execute_system_command(
-"$mysqlcmd $mysqllogin -Bse \"SELECT 1 FROM information_schema.columns WHERE TABLE_SCHEMA = 'mysql' AND TABLE_NAME = 'user' AND COLUMN_NAME = 'password'\" 2>>$devnull"
-        );
-        my $result_auth = execute_system_command(
-"$mysqlcmd $mysqllogin -Bse \"SELECT 1 FROM information_schema.columns WHERE TABLE_SCHEMA = 'mysql' AND TABLE_NAME = 'user' AND COLUMN_NAME = 'authentication_string'\" 2>>$devnull"
-        );
-        if ( $result_pass && $result_auth ) {
-            $PASS_COLUMN_NAME =
-"IF(plugin='mysql_native_password', authentication_string, password)";
-        }
-        elsif ($result_auth) {
-            $PASS_COLUMN_NAME = 'authentication_string';
-        }
-        elsif ( !$result_pass ) {
-            infoprint "Skipped due to none of known auth columns exists";
-            return;
-        }
+    my @mysql_user_columns = select_table_columns_db( 'mysql', 'user' );
+    if ( grep { /^authentication_string$/msx } @mysql_user_columns ) {
+        $PASS_COLUMN_NAME = 'authentication_string';
     }
+    elsif ( grep { /^Password$/msx } @mysql_user_columns ) {
+        $PASS_COLUMN_NAME = 'Password';
+    }
+    else {
+        badprint 'Skipped because could not determine auth column';
+        return;
+    }
+
     debugprint "Password column = $PASS_COLUMN_NAME";
 
     # IS THERE A ROLE COLUMN


### PR DESCRIPTION
Better and much simpler logic.

However, needs testing across all supported MariaDB and MySQL versions.

Future: if **mysql.global_priv** table exists, use that instead:

`SELECT JSON_VALUE(Priv, '$.authentication_string') authentication_string FROM mysql.global_priv;`

## Summary by Sourcery

Simplify and harden detection of the authentication column in the mysql.user table when generating security recommendations.

Bug Fixes:
- Correctly determine the password/authentication column in mysql.user across different MySQL and MariaDB versions, avoiding skipped checks when schemas differ.

Enhancements:
- Replace version-based logic with schema inspection of mysql.user to select the appropriate authentication column and provide clearer feedback when it cannot be determined.