### PR TITLE
Make Storage Engine Statistics output deterministic

### DIFF
--- a/mysqltuner.pl
+++ b/mysqltuner.pl
@@ -4084,7 +4084,8 @@ sub check_storage_engines {
             }
         }
     }
-    while ( my ( $engine, $size ) = each(%enginestats) ) {
+    foreach my $engine ( sort keys %enginestats ) {
+        my $size = $enginestats{$engine};
         infoprint "Data in $engine tables: "
           . hr_bytes($size)
           . " (Tables: "


### PR DESCRIPTION
Fixes #26 Engine sizes are printed in random order in Storage Engine Statistics section

## Summary by Sourcery

Bug Fixes:
- Ensure storage engine size statistics are listed in a consistent, predictable order instead of varying between runs.