### PR TITLE
Change default update check back to disabled

### DIFF
--- a/mysqltuner.pl
+++ b/mysqltuner.pl
@@ -205,7 +205,7 @@ our %CLI_METADATA = (
     },
     'checkversion' => {
         type    => '!',
-        default => 1,
+        default => 0,
         desc    => 'Check for updates to MySQLTuner',
         cat     => 'PERFORMANCE'
     },


### PR DESCRIPTION
This reverts https://github.com/major/MySQLTuner-perl/commit/460a1851a1f3b7eafe7ab104d7eae5ce4c1cc979

This produces a unexpected "phone-home" situation, that will also on protected systems not work due to firewalls. It should not connect to external systems if not asked for.

It was fixed in 2024 before --> https://github.com/major/MySQLTuner-perl/issues/760

## Summary by Sourcery

Enhancements:
- Change the default configuration of the version check option so that update checks are opt-in instead of enabled by default.