### PR TITLE
Added support for MariaDB 12.3 (latest LTS version)

### DIFF
--- a/mariadb_support.md
+++ b/mariadb_support.md
@@ -2,6 +2,7 @@
 
 | Version | End of Support Date | LTS | Status |
 |---------|------------------------|-----|--------|
+| 12.3 | 2029-06-30 | YES | Supported |
 | 12.0 | 2025-11-18 | NO | Outdated |
 | 11.8 | 2028-06-04 | YES | Supported |
 | 11.7 | 2025-05-12 | NO | Outdated |

--- a/mysqltuner.pl
+++ b/mysqltuner.pl
@@ -5508,7 +5508,9 @@ sub validate_mysql_version {
         or mysql_version_eq( 10, 6 )
         or mysql_version_eq( 10, 11 )
         or mysql_version_eq( 11, 4 )
-        or mysql_version_eq( 11, 8 ) )
+        or mysql_version_eq( 11, 8 )
+        or mysql_version_eq( 12, 3 )
+    )
     {
         goodprint "Currently running supported MySQL/MariaDB version "
           . $myvar{'version'} . "(LTS)";


### PR DESCRIPTION
Hi!

Just created this small change since I'm currently working with the latest MariaDB LTS version and I realized MySQLTuner wouldn't recognize 12.3 as LTS yet.

Let me know if I missed anything.

Regards
Z

## Summary by Sourcery

Add recognition of MariaDB 12.3 as a supported LTS version.

New Features:
- Treat MariaDB 12.3 installations as running a supported LTS version in version validation.

Documentation:
- Document MariaDB 12.3 as a supported LTS release with its end-of-support date in the MariaDB support matrix.